### PR TITLE
Update PBN parser to fix comment separation

### DIFF
--- a/lib/pbn-stream.js
+++ b/lib/pbn-stream.js
@@ -118,7 +118,7 @@ PbnStream.prototype._transform = function(line, encoding, done) {
         this.ingame = false;
     }
     else if (line.includes('{')) {
-        const braceIndex = line.indexOf('{')
+        let braceIndex = line.indexOf('{');
         this.comment = {
             type: 'comment',
             text: ''

--- a/lib/pbn-stream.js
+++ b/lib/pbn-stream.js
@@ -54,7 +54,7 @@ function parseDeal(s) {
 
 PbnStream.prototype._transform = function(line, encoding, done) {
     if (this.comment) {
-        if (line[0] === '}') {
+        if (line.endsWith('}')) {
             this.produce(this.comment);
             this.comment = undefined;
         }
@@ -117,13 +117,14 @@ PbnStream.prototype._transform = function(line, encoding, done) {
         this.produce(null);
         this.ingame = false;
     }
-    else if (line[0] === '{') {
+    else if (line.includes('{')) {
+        const braceIndex = line.indexOf('{')
         this.comment = {
             type: 'comment',
             text: ''
         };
-        let rest = line.slice(1).trim();
-        if (rest[rest.length - 1] === '}') {
+        let rest = line.slice(braceIndex + 1).trim();
+        if (rest.endsWith('}')) {
             this.comment.text = rest.slice(0, -1).trim();
             this.produce(this.comment);
             this.comment = undefined;
@@ -162,8 +163,9 @@ PbnStream.prototype.produce = function(data) {
         this.produce(tag);
     }
 
-    if (data !== null)
+    if (data !== null) {
         this.push(data);
+    }
 };
 
 let pbn = opts => pipe(lines(), new PbnStream(opts));

--- a/package.json
+++ b/package.json
@@ -21,6 +21,12 @@
     "name": "Richard Schneider",
     "email": "makaretu@gmail.com"
   },
+  "contributors": [
+    {
+      "name": "Peter Kaukov",
+      "email": "peter.kaukov@gmail.com"
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/richardschneider/pbn"


### PR DESCRIPTION
Currently, when a multi-line comment starting with { and
immediately followed by content, but the content ends a few lines below,
OR a comment that is part of the data, is not parsed properly.